### PR TITLE
fix ruamel.yaml on 0.14.X for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         version='0.1.4',
         scripts=['yamlfmt'],
         license='[MPLv2.0](https://mozilla.org/MPL/2.0/)',
-        install_requires=['ruamel.yaml'],
+        install_requires=['ruamel.yaml<0.15'],
         classifiers=[
             'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
             'Programming Language :: Python :: 3',


### PR DESCRIPTION
Thank you for using ruamel.yaml. 

There will be API changes in the 0.15+ versions, that might lead to warnings that 
your users could see. 
Therefore please release a version of your package with this change, so that it will not 
automatically take the latest ruamel.yaml release.